### PR TITLE
Change Exception class to Throwable for laravel7

### DIFF
--- a/src/Codeception/Lib/Connector/Laravel5/ExceptionHandlerDecorator.php
+++ b/src/Codeception/Lib/Connector/Laravel5/ExceptionHandlerDecorator.php
@@ -1,7 +1,7 @@
 <?php
 namespace Codeception\Lib\Connector\Laravel5;
 
-use Exception;
+use Throwable;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 /**
@@ -42,32 +42,32 @@ class ExceptionHandlerDecorator implements ExceptionHandlerContract
     /**
      * Report or log an exception.
      *
-     * @param  \Exception $e
+     * @param  \Throwable $e
      * @return void
      */
-    public function report(Exception $e)
+    public function report(Throwable $e)
     {
         $this->laravelExceptionHandler->report($e);
     }
-    
+
     /**
       * Determine if the exception should be reported.
      *
-     * @param  \Exception $e
+     * @param  \Throwable $e
      * @return bool
      */
-    public function shouldReport(Exception $e)
+    public function shouldReport(Throwable $e)
     {
         return $this->exceptionHandlingDisabled;
     }
 
     /**
      * @param $request
-     * @param Exception $e
+     * @param Throwable $e
      * @return \Symfony\Component\HttpFoundation\Response
-     * @throws Exception
+     * @throws Throwable
      */
-    public function render($request, Exception $e)
+    public function render($request, Throwable $e)
     {
         $response = $this->laravelExceptionHandler->render($request, $e);
 
@@ -97,10 +97,10 @@ class ExceptionHandlerDecorator implements ExceptionHandlerContract
      * Render an exception to the console.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface $output
-     * @param  \Exception $e
+     * @param  \Throwable $e
      * @return void
      */
-    public function renderForConsole($output, Exception $e)
+    public function renderForConsole($output, Throwable $e)
     {
         $this->laravelExceptionHandler->renderForConsole($output, $e);
     }


### PR DESCRIPTION
There is a problem in compatibility of this module with Laravel 7. [`ExceptionHandler` contract](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Contracts/Debug/ExceptionHandler.php#L7) was changed. Now it using `Throwable` instead of `Exception`. So all tests with Codeception and Laravel7 are failing.

This is a small fix to make module compatible with Laravel7.